### PR TITLE
Handle cmd.exe line endings on Windows better

### DIFF
--- a/t/11-redirect-oo.t
+++ b/t/11-redirect-oo.t
@@ -16,7 +16,7 @@ my $slurp = do{ undef $/; <TMP> };
 
 #Special case for CMD lameness, see diag below
 if( $^O =~ /MSWin32/ ){
-  $slurp =~ s/\r\n$//;
+  $slurp =~ s/\n$//;
 }
 
 our $txt; require 't/08-redirect.pl';


### PR DESCRIPTION
Perl uses `\n` as the logical newline depending upon the given platform.  Thus the special case for CMD lameness can be simplified, causing the tests to pass even on Windows when using `cmd.exe`.
This has been checked on Windows 7 with Strawberry Perl 5.18.4.1 (64 bit) as well as on Linux (Debian/jessie amd64) (perl-5.20).
