### PR TITLE
Fix "Use of uninitialized value" warning.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ WriteMakefile(
        'Env'            => 0,
        'Exporter'       => 0,
        'File::Temp'     => 0,
+       'Test::NoWarnings' => 0,
     },
     'PREREQ_PM'         => {
        'base'           => 0,

--- a/lib/IO/Pager.pm
+++ b/lib/IO/Pager.pm
@@ -95,7 +95,7 @@ sub new(*;$@) { # FH, [MODE], [CLASS]
     warn "REMAINDER? (@_)", scalar @_;
     push(@_, $args{procedural});
   }
-  else{
+  elsif (defined $_[1]) {
     $args{mode} = splice(@_, 1, 1) if $_[1] =~ /^:/;
     $args{subclass} = pop if exists($_[1]);
   }

--- a/t/01-new.t
+++ b/t/01-new.t
@@ -1,0 +1,9 @@
+#!/usr/bin/perl -w
+
+use strict;
+use warnings;
+use Test::More tests => 2;
+use IO::Pager;
+use Test::NoWarnings;
+
+ok my $pager = IO::Pager->new(\*STDOUT), 'Connect to STDOUT';


### PR DESCRIPTION
Only happens, as far as I can tell, when using the Perl -w option and passing a single value to the constructor. So add a test for that and fail on the warning, then fix it.

Cc: @belg4mit.
